### PR TITLE
fix: history files to use XDG_DATA_HOME

### DIFF
--- a/rules.yaml
+++ b/rules.yaml
@@ -124,10 +124,10 @@ rules:
     actions:
       - type: migrate
         source: ${HOME}/.bash_history
-        dest: ${XDG_CACHE_HOME}/bash/history
+        dest: ${XDG_DATA_HOME}/bash/history
       - type: export
         key: HISTFILE
-        value: ${XDG_CACHE_HOME}/bash/history
+        value: ${XDG_DATA_HOME}/bash/history
 
   - name: barnard
     dotfile:
@@ -258,10 +258,10 @@ rules:
         command: cqlsh --cqlshrc $XDG_CONFIG_HOME/cassandra/cqlshrc
       - type: migrate
         source: ${HOME}/.cassandra/cqlsh_history
-        dest: ${XDG_CACHE_HOME}/cassandra/cqlsh_history
+        dest: ${XDG_DATA_HOME}/cassandra/cqlsh_history
       - type: export
         key: CQL_HISTORY
-        value: ${XDG_CACHE_HOME}/cassandra/cqlsh_history
+        value: ${XDG_DATA_HOME}/cassandra/cqlsh_history
 
   - name: docker
     dotfile:
@@ -524,10 +524,10 @@ rules:
     actions:
       - type: migrate
         source: ${HOME}/.lesshst
-        dest: ${XDG_CACHE_HOME}/less/history
+        dest: ${XDG_DATA_HOME}/less/history
       - type: export
         key: LESSHISTFILE
-        value: ${XDG_CACHE_HOME}/less/history
+        value: ${XDG_DATA_HOME}/less/history
       - type: export
         key: LESSKEY
         value: ${XDG_CONFIG_HOME}/less/lesskey
@@ -743,10 +743,10 @@ rules:
     actions:
       - type: migrate
         source: ${HOME}/.node_repl_history
-        dest: ${XDG_CACHE_HOME}/node_repl_history
+        dest: ${XDG_DATA_HOME}/node_repl_history
       - type: export
         key: NODE_REPL_HISTORY
-        value: ${XDG_CACHE_HOME}/node_repl_history
+        value: ${XDG_DATA_HOME}/node_repl_history
 
   - name: npm
     dotfile:
@@ -1210,10 +1210,10 @@ rules:
     actions:
       - type: migrate
         source: ${HOME}/.psql_history
-        dest: ${XDG_CACHE_HOME}/psql_history
+        dest: ${XDG_DATA_HOME}/psql_history
       - type: export
         key: PSQL_HISTORY
-        value: ${XDG_CACHE_HOME}/psql_history
+        value: ${XDG_DATA_HOME}/psql_history
 
   - name: psqlrc
     dotfile:


### PR DESCRIPTION
According to the XDG Base Directory Specification, history files should be stored in XDG_DATA_HOME as they contain user-specific data that should be preserved, not in XDG_CACHE_HOME which is for temporary cache files.

This change makes the following applications consistent with other history files already using XDG_DATA_HOME:
- bash_history: /home/lime/.bash_history
- cassandra: /home/lime/.cassandra/cqlsh_history
- less: /home/lime/.lesshst
- node_repl_history: /home/lime/.node_repl_history
- psql_history: /home/lime/.psql_history

Fixes the inconsistency where some history files were using XDG_CACHE_HOME while others (mysql, redis, tig, etc.) were correctly using XDG_DATA_HOME.

Source: https://github.com/doron-cohen/antidot/pull/273