### PR TITLE
Update fork references from doron-cohen to bad3r

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Generate release tarball
         run: |
           VERSION=${GITHUB_REF_NAME#v}
-          tar czf antidot-${VERSION}.tar.gz --transform "s,^,antidot-${VERSION}/," --exclude dist *
+          tar czf "antidot-${VERSION}.tar.gz" --transform "s,^,antidot-${VERSION}/," --exclude dist ./*
 
       - name: Upload release tarball
         uses: softprops/action-gh-release@72f2c25fcb47643c292f7107632f7a47c1df5cd8 # v2.3.2

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -79,14 +79,14 @@ changelog:
 brews:
   - name: antidot
     folder: Formula
-    homepage: "https://github.com/doron-cohen/antidot"
+    homepage: "https://github.com/bad3r/antidot"
     description: "Cleans up your $HOME from those pesky dotfiles"
-    url_template: "https://github.com/doron-cohen/antidot/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+    url_template: "https://github.com/bad3r/antidot/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
     skip_upload: false
     ids:
       - release
     tap:
-      owner: doron-cohen
+      owner: bad3r
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
     commit_author:

--- a/ci/aur/publish.sh
+++ b/ci/aur/publish.sh
@@ -36,7 +36,7 @@ fi
 
 export DESCRIPTION="Cleans up your \$HOME from those pesky dotfiles"
 export BINARY_NAME="antidot"
-export REPO_URL="https://github.com/doron-cohen/antidot"
+export REPO_URL="https://github.com/bad3r/antidot"
 
 ENVSUBST_VARS="\$PKGVER \$VERSION \$RELEASE \$SHA256SUM \$DESCRIPTION \$BINARY_NAME \$REPO_URL"
 

--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -7,10 +7,10 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/doron-cohen/antidot/internal/rules"
-	"github.com/doron-cohen/antidot/internal/shell"
-	"github.com/doron-cohen/antidot/internal/tui"
-	"github.com/doron-cohen/antidot/internal/utils"
+	"github.com/bad3r/antidot/internal/rules"
+	"github.com/bad3r/antidot/internal/shell"
+	"github.com/bad3r/antidot/internal/tui"
+	"github.com/bad3r/antidot/internal/utils"
 )
 
 func init() {

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -3,8 +3,8 @@ package cmd
 import (
 	"github.com/spf13/cobra"
 
-	sh "github.com/doron-cohen/antidot/internal/shell"
-	"github.com/doron-cohen/antidot/internal/tui"
+	sh "github.com/bad3r/antidot/internal/shell"
+	"github.com/bad3r/antidot/internal/tui"
 )
 
 func init() {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/doron-cohen/antidot/internal/tui"
-	"github.com/doron-cohen/antidot/internal/utils"
+	"github.com/bad3r/antidot/internal/tui"
+	"github.com/bad3r/antidot/internal/utils"
 )
 
 var rulesFilePath string

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -1,8 +1,8 @@
 package cmd
 
 import (
-	"github.com/doron-cohen/antidot/internal/tui"
-	"github.com/doron-cohen/antidot/internal/utils"
+	"github.com/bad3r/antidot/internal/tui"
+	"github.com/bad3r/antidot/internal/utils"
 	"github.com/spf13/cobra"
 )
 
@@ -10,7 +10,7 @@ func init() {
 	rootCmd.AddCommand(updateCmd)
 }
 
-var rulesSource = "https://raw.githubusercontent.com/doron-cohen/antidot/master/rules.yaml"
+var rulesSource = "https://raw.githubusercontent.com/bad3r/antidot/master/rules.yaml"
 
 var updateCmd = &cobra.Command{
 	Use:   "update",

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/doron-cohen/antidot
+module github.com/bad3r/antidot
 
 go 1.21
 

--- a/internal/rules/action.go
+++ b/internal/rules/action.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/mitchellh/mapstructure"
 
-	"github.com/doron-cohen/antidot/internal/shell"
+	"github.com/bad3r/antidot/internal/shell"
 )
 
 type ActionContext struct {

--- a/internal/rules/alias.go
+++ b/internal/rules/alias.go
@@ -1,7 +1,7 @@
 package rules
 
 import (
-	"github.com/doron-cohen/antidot/internal/tui"
+	"github.com/bad3r/antidot/internal/tui"
 )
 
 type Alias struct {

--- a/internal/rules/alias_test.go
+++ b/internal/rules/alias_test.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/doron-cohen/antidot/internal/rules"
-	"github.com/doron-cohen/antidot/internal/shell"
-	"github.com/doron-cohen/antidot/internal/utils"
+	"github.com/bad3r/antidot/internal/rules"
+	"github.com/bad3r/antidot/internal/shell"
+	"github.com/bad3r/antidot/internal/utils"
 )
 
 func TestAliasNoEnv(t *testing.T) {

--- a/internal/rules/config.go
+++ b/internal/rules/config.go
@@ -4,7 +4,7 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/doron-cohen/antidot/internal/tui"
+	"github.com/bad3r/antidot/internal/tui"
 	"github.com/mitchellh/mapstructure"
 	"gopkg.in/yaml.v2"
 )

--- a/internal/rules/config_test.go
+++ b/internal/rules/config_test.go
@@ -7,9 +7,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/doron-cohen/antidot/internal/dotfile"
+	"github.com/bad3r/antidot/internal/dotfile"
 
-	"github.com/doron-cohen/antidot/internal/rules"
+	"github.com/bad3r/antidot/internal/rules"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/internal/rules/delete.go
+++ b/internal/rules/delete.go
@@ -3,8 +3,8 @@ package rules
 import (
 	"os"
 
-	"github.com/doron-cohen/antidot/internal/tui"
-	"github.com/doron-cohen/antidot/internal/utils"
+	"github.com/bad3r/antidot/internal/tui"
+	"github.com/bad3r/antidot/internal/utils"
 )
 
 type Delete struct {

--- a/internal/rules/delete_test.go
+++ b/internal/rules/delete_test.go
@@ -6,9 +6,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/doron-cohen/antidot/internal/rules"
-	"github.com/doron-cohen/antidot/internal/shell"
-	"github.com/doron-cohen/antidot/internal/utils"
+	"github.com/bad3r/antidot/internal/rules"
+	"github.com/bad3r/antidot/internal/shell"
+	"github.com/bad3r/antidot/internal/utils"
 )
 
 func TestDeleteApply(t *testing.T) {

--- a/internal/rules/export.go
+++ b/internal/rules/export.go
@@ -1,7 +1,7 @@
 package rules
 
 import (
-	"github.com/doron-cohen/antidot/internal/tui"
+	"github.com/bad3r/antidot/internal/tui"
 )
 
 type Export struct {

--- a/internal/rules/export_test.go
+++ b/internal/rules/export_test.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/doron-cohen/antidot/internal/rules"
-	"github.com/doron-cohen/antidot/internal/shell"
-	"github.com/doron-cohen/antidot/internal/utils"
+	"github.com/bad3r/antidot/internal/rules"
+	"github.com/bad3r/antidot/internal/shell"
+	"github.com/bad3r/antidot/internal/utils"
 )
 
 func TestExportNoEnv(t *testing.T) {

--- a/internal/rules/migrate.go
+++ b/internal/rules/migrate.go
@@ -4,8 +4,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/doron-cohen/antidot/internal/tui"
-	"github.com/doron-cohen/antidot/internal/utils"
+	"github.com/bad3r/antidot/internal/tui"
+	"github.com/bad3r/antidot/internal/utils"
 )
 
 type Migrate struct {

--- a/internal/rules/migrate_test.go
+++ b/internal/rules/migrate_test.go
@@ -6,9 +6,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/doron-cohen/antidot/internal/rules"
-	"github.com/doron-cohen/antidot/internal/shell"
-	"github.com/doron-cohen/antidot/internal/utils"
+	"github.com/bad3r/antidot/internal/rules"
+	"github.com/bad3r/antidot/internal/shell"
+	"github.com/bad3r/antidot/internal/utils"
 )
 
 func TestMigrateApply(t *testing.T) {

--- a/internal/rules/rule.go
+++ b/internal/rules/rule.go
@@ -1,8 +1,8 @@
 package rules
 
 import (
-	"github.com/doron-cohen/antidot/internal/dotfile"
-	"github.com/doron-cohen/antidot/internal/tui"
+	"github.com/bad3r/antidot/internal/dotfile"
+	"github.com/bad3r/antidot/internal/tui"
 )
 
 type Rule struct {

--- a/internal/shell/bash.go
+++ b/internal/shell/bash.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/doron-cohen/antidot/internal/utils"
+	"github.com/bad3r/antidot/internal/utils"
 )
 
 type Bash struct{}

--- a/internal/shell/bash_test.go
+++ b/internal/shell/bash_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/doron-cohen/antidot/internal/shell"
+	"github.com/bad3r/antidot/internal/shell"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/shell/fish.go
+++ b/internal/shell/fish.go
@@ -5,7 +5,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/doron-cohen/antidot/internal/utils"
+	"github.com/bad3r/antidot/internal/utils"
 )
 
 type Fish struct{}

--- a/internal/shell/fish_test.go
+++ b/internal/shell/fish_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/doron-cohen/antidot/internal/shell"
+	"github.com/bad3r/antidot/internal/shell"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/shell/keyvalue.go
+++ b/internal/shell/keyvalue.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"sync"
 
-	"github.com/doron-cohen/antidot/internal/tui"
-	"github.com/doron-cohen/antidot/internal/utils"
+	"github.com/bad3r/antidot/internal/tui"
+	"github.com/bad3r/antidot/internal/utils"
 )
 
 type KeyValueStore struct {

--- a/internal/shell/keyvalue_test.go
+++ b/internal/shell/keyvalue_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/doron-cohen/antidot/internal/shell"
+	"github.com/bad3r/antidot/internal/shell"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/internal/shell/shell_test.go
+++ b/internal/shell/shell_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/doron-cohen/antidot/internal/shell"
+	"github.com/bad3r/antidot/internal/shell"
 )
 
 type TestSh struct{}

--- a/internal/utils/env.go
+++ b/internal/utils/env.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/adrg/xdg"
 
-	"github.com/doron-cohen/antidot/internal/tui"
+	"github.com/bad3r/antidot/internal/tui"
 )
 
 func GetHomeDir() (string, error) {

--- a/internal/utils/fetch.go
+++ b/internal/utils/fetch.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"path"
 
-	"github.com/doron-cohen/antidot/internal/tui"
+	"github.com/bad3r/antidot/internal/tui"
 )
 
 func Download(src, dest string) error {

--- a/internal/utils/files.go
+++ b/internal/utils/files.go
@@ -6,7 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/doron-cohen/antidot/internal/tui"
+	"github.com/bad3r/antidot/internal/tui"
 	"github.com/otiai10/copy"
 )
 

--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/doron-cohen/antidot/cmd"
+	"github.com/bad3r/antidot/cmd"
 )
 
 /*

--- a/tests/integration/init_test.go
+++ b/tests/integration/init_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/doron-cohen/antidot/tests"
+	"github.com/bad3r/antidot/tests"
 	"github.com/stretchr/testify/require"
 )
 

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/doron-cohen/antidot/internal/utils"
+	"github.com/bad3r/antidot/internal/utils"
 	"github.com/stretchr/testify/require"
 )
 


### PR DESCRIPTION
## Summary
- Updates all repository references to point to this fork (bad3r/antidot)
- Maintains functionality while allowing independent development on the fork
- Ensures GitHub Actions workflows follow best practices

## Changes
- Updated Go import paths in all source files
- Updated release configuration in .goreleaser.yml
- Updated CI/CD references in publish scripts
- Updated test utilities to reference fork
- Fixed actionlint warnings (if applicable)

## Test plan
- [x] Run actionlint to verify GitHub Actions workflows
- [x] Run GitHub Actions locally with `act` to verify CI/CD pipeline
- [x] Ensure imports resolve correctly with fork paths
- [x] Verify build process works with updated references
- [x] Check release configuration points to correct repository