### PR TITLE
Rename repository from antidot to antidot-home

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,11 +70,11 @@ jobs:
 
       - name: Build Binary
         run: |
-          go build -v -o antidot .
-          ./antidot --version
+          go build -v -o antidot-home .
+          ./antidot-home --version
 
       - name: Build with Race Detector
-        run: go build -race -v -o antidot-race .
+        run: go build -race -v -o antidot-home-race .
 
       - name: Trim Go Cache
         if: ${{ github.ref == 'refs/heads/main' && matrix.os == 'ubuntu-latest' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,12 +35,12 @@ jobs:
       - name: Generate release tarball
         run: |
           VERSION=${GITHUB_REF_NAME#v}
-          tar czf "antidot-${VERSION}.tar.gz" --transform "s,^,antidot-${VERSION}/," --exclude dist ./*
+          tar czf "antidot-home-${VERSION}.tar.gz" --transform "s,^,antidot-home-${VERSION}/," --exclude dist ./*
 
       - name: Upload release tarball
         uses: softprops/action-gh-release@72f2c25fcb47643c292f7107632f7a47c1df5cd8 # v2.3.2
         with:
-          files: antidot-*.tar.gz
+          files: antidot-home-*.tar.gz
           append_body: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
           check-latest: true
 
       - name: Build Binary for Tests
-        run: go build -o antidot .
+        run: go build -o antidot-home .
 
       - name: Run Tests
         run: go test -json ./... > test_results.json

--- a/.gitignore
+++ b/.gitignore
@@ -31,5 +31,5 @@ build/
 /Godeps/
 
 ### Binaries ###
-antidot
+antidot-home
 main

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,8 +4,8 @@ before:
     - go mod vendor
 
 builds:
-  - id: antidot-linux
-    binary: antidot
+  - id: antidot-home-linux
+    binary: antidot-home
     ldflags:
       - -s -w -X 'main.version={{ .Version }}'
     env:
@@ -14,8 +14,8 @@ builds:
       - linux
     goarch:
       - amd64
-  - id: antidot-darwin
-    binary: antidot
+  - id: antidot-home-darwin
+    binary: antidot-home
     ldflags:
       - -s -w -X 'main.version={{ .Version }}'
     env:
@@ -30,8 +30,8 @@ archives:
     name_template: "{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     format: tar.gz
     builds:
-      - antidot-linux
-      - antidot-darwin
+      - antidot-home-linux
+      - antidot-home-darwin
     replacements:
       darwin: Darwin
       linux: Linux
@@ -43,8 +43,8 @@ archives:
     name_template: "{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     format: binary
     builds:
-      - antidot-linux
-      - antidot-darwin
+      - antidot-home-linux
+      - antidot-home-darwin
     replacements:
       darwin: Darwin
       linux: Linux

--- a/README.md
+++ b/README.md
@@ -1,25 +1,25 @@
-# antidot :house: :small_orange_diamond: :boom:
+# AntiDot Home :house: :small_orange_diamond: :boom:
 
-![Pipeline](https://github.com/bad3r/antidot/workflows/Pipeline/badge.svg?branch=main)
+![Pipeline](https://github.com/bad3r/antidot-home/workflows/Pipeline/badge.svg?branch=main)
 
 Cleans up your `$HOME` from those pesky dotfiles.
 
 ## Migration from Pre 0.6.0 Versions
 
-Please backup your environment variable and aliases files (in `$XDG_DATA_HOME/antidot/{env,alias}.*`). After version 0.6.0 antidot stores env exports and alias definitions in a JSON file and generates from it shell definition files.
+Please backup your environment variable and aliases files (in `$XDG_DATA_HOME/antidot-home/{env,alias}.*`). After version 0.6.0 antidot-home stores env exports and alias definitions in a JSON file and generates from it shell definition files.
 
 ## Intro
 
 For years I stood by and saw how countless applications populate my home dir with dotfiles.
 
-No more! `antidot` is a tool to automatically detect and remove dotfiles from `$HOME` without any risks. It will move files to more appropriate locations (based on [XDG base directory specifications](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html)). It will also set environment variables, declare aliases and use symlinks to ensure apps can find their files.
+No more! `antidot-home` is a tool to automatically detect and remove dotfiles from `$HOME` without any risks. It will move files to more appropriate locations (based on [XDG base directory specifications](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html)). It will also set environment variables, declare aliases and use symlinks to ensure apps can find their files.
 
 ## Installation
 
 ### Arch Linux
 
 ```shell
-yay -Sy antidot-bin
+yay -Sy antidot-home-bin
 ```
 
 ### Homebrew
@@ -30,13 +30,13 @@ Not available. Use the original verison form [doron-cohen/antidot](https://githu
 brew install doron-cohen/tap/antidot
 ```
 
-Go to the [releases](https://github.com/bad3r/antidot/releases) section and grab the one that fits your OS.
+Go to the [releases](https://github.com/bad3r/antidot-home/releases) section and grab the one that fits your OS.
 
-After installing run `antidot update` to download the latest rules file and you're all set!
+After installing run `antidot-home update` to download the latest rules file and you're all set!
 
 ## How does it Work?
 
-Dotfiles pollution is a complex problem to solve. There are many approaches to solve this annoying issue and `antidot` is taking the safest one.
+Dotfiles pollution is a complex problem to solve. There are many approaches to solve this annoying issue and `antidot-home` is taking the safest one.
 
 We maintain a rule for each dotfile which applies actions when the file is detected. The main goal is to move the files to the most appropriate location while keeping the application working as expected.
 
@@ -65,16 +65,16 @@ This is the rule for the Docker configuration directory:
         value: ${XDG_CONFIG_HOME}/docker
 ```
 
-When running `antidot clean` we will be prompted about this directory:
+When running `antidot-home clean` we will be prompted about this directory:
 
 ```bash
-❯ ./antidot clean
+❯ ./antidot-home clean
 Rule docker:
   MOVE   /Users/doroncohen/.docker → /Users/doroncohen/.config/docker
   EXPORT DOCKER_CONFIG="${XDG_CONFIG_HOME}/docker"
 ? Apply rule docker? (y/N)
 ```
 
-Answering yes will move the directory and write the environment variable to a file that can be easily sourced by the shell. Running `antidot init` will create a shell script that will do just that.
+Answering yes will move the directory and write the environment variable to a file that can be easily sourced by the shell. Running `antidot-home init` will create a shell script that will do just that.
 
-Adding `eval "$(antidot init)"` to your `.bashrc` or `.zshrc` will make sure you shell sessions will see these variables and aliases. In Fish the proper way is to run `antidot init | source`. You could add it to `$__fish_config_dir/conf.d/antidot.fish`.
+Adding `eval "$(antidot-home init)"` to your `.bashrc` or `.zshrc` will make sure you shell sessions will see these variables and aliases. In Fish the proper way is to run `antidot-home init | source`. You could add it to `$__fish_config_dir/conf.d/antidot-home.fish`.

--- a/ci/aur/publish.sh
+++ b/ci/aur/publish.sh
@@ -17,7 +17,7 @@ export GIT_SSH_COMMAND="ssh -i ~/.ssh/aur.key -o UserKnownHostsFile=/dev/null -o
 cd ${ROOT}/ci/aur
 
 rm -rf aur-package-repo
-git clone aur@aur.archlinux.org:antidot-bin aur-package-repo 2>&1
+git clone aur@aur.archlinux.org:antidot-home-bin aur-package-repo 2>&1
 
 export SHA256SUM=$(sha256sum ${BINARY_PATH} | awk '{ print $1 }')
 
@@ -35,8 +35,8 @@ else
 fi
 
 export DESCRIPTION="Cleans up your \$HOME from those pesky dotfiles"
-export BINARY_NAME="antidot"
-export REPO_URL="https://github.com/bad3r/antidot"
+export BINARY_NAME="antidot-home"
+export REPO_URL="https://github.com/bad3r/antidot-home"
 
 ENVSUBST_VARS="\$PKGVER \$VERSION \$RELEASE \$SHA256SUM \$DESCRIPTION \$BINARY_NAME \$REPO_URL"
 

--- a/ci/aur/templates/.SRCINFO
+++ b/ci/aur/templates/.SRCINFO
@@ -1,11 +1,11 @@
-pkgbase = antidot-bin
+pkgbase = antidot-home-bin
 	pkgdesc = ${DESCRIPTION}
 	url = ${REPO_URL}
 	license = MIT
 	arch = x86_64
 	pkgver = ${PKGVER}
 	pkgrel = ${RELEASE}
-	source = antidot-${VERSION}.bin::${REPO_URL}/releases/download/v${VERSION}/antidot_${VERSION}_linux_amd64
+	source = antidot-home-${VERSION}.bin::${REPO_URL}/releases/download/v${VERSION}/antidot-home_${VERSION}_linux_amd64
 	sha256sums = ${SHA256SUM}
 
-pkgname = antidot-bin
+pkgname = antidot-home-bin

--- a/ci/aur/templates/PKGBUILD
+++ b/ci/aur/templates/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Alex Dewar <a.dewar@sussex.ac.uk>
 # Maintainer: Doron Cohen <me@doron.dev>
 
-pkgname=antidot-bin
+pkgname=antidot-home-bin
 pkgdesc="${DESCRIPTION}"
 url="${REPO_URL}"
 license=("MIT")
@@ -10,13 +10,13 @@ arch=("x86_64")
 pkgver=${PKGVER}
 pkgrel=${RELEASE}
 
-provides=("antidot")
-conflicts=("antidot")
+provides=("antidot-home")
+conflicts=("antidot-home")
 depends=()
 
-source=("antidot-${VERSION}.bin::${REPO_URL}/releases/download/v${VERSION}/antidot_${VERSION}_linux_amd64")
+source=("antidot-home-${VERSION}.bin::${REPO_URL}/releases/download/v${VERSION}/antidot-home_${VERSION}_linux_amd64")
 sha256sums=("${SHA256SUM}")
 
 package() {
-  install -Dm 0755 "$srcdir/antidot-${VERSION}.bin" "$pkgdir/usr/bin/antidot"
+  install -Dm 0755 "$srcdir/antidot-home-${VERSION}.bin" "$pkgdir/usr/bin/antidot-home"
 }

--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -7,10 +7,10 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/bad3r/antidot/internal/rules"
-	"github.com/bad3r/antidot/internal/shell"
-	"github.com/bad3r/antidot/internal/tui"
-	"github.com/bad3r/antidot/internal/utils"
+	"github.com/bad3r/antidot-home/internal/rules"
+	"github.com/bad3r/antidot-home/internal/shell"
+	"github.com/bad3r/antidot-home/internal/tui"
+	"github.com/bad3r/antidot-home/internal/utils"
 )
 
 func init() {
@@ -29,7 +29,7 @@ var cleanCmd = &cobra.Command{
 		rulesConfig, err := rules.LoadRulesConfig(rulesFilePath)
 		if err != nil {
 			if _, rulesMissing := err.(*rules.MissingRulesFile); rulesMissing {
-				tui.Print("Couldn't find rules file. Please run `antidot update`.")
+				tui.Print("Couldn't find rules file. Please run `antidot-home update`.")
 				os.Exit(2)
 			}
 			tui.FatalIfError("Failed to read rules file", err)
@@ -71,7 +71,7 @@ var cleanCmd = &cobra.Command{
 		if appliedRule {
 			tui.Print(
 				"Cleanup finished - run %s to take effect",
-				tui.ApplyStyle(tui.Blue, "eval \"$(antidot init)\""),
+				tui.ApplyStyle(tui.Blue, "eval \"$(antidot-home init)\""),
 			)
 		} else {
 			tui.Print("No dotfiles detected in home directory. You're all clean!")

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -3,8 +3,8 @@ package cmd
 import (
 	"github.com/spf13/cobra"
 
-	sh "github.com/bad3r/antidot/internal/shell"
-	"github.com/bad3r/antidot/internal/tui"
+	sh "github.com/bad3r/antidot-home/internal/shell"
+	"github.com/bad3r/antidot-home/internal/tui"
 )
 
 func init() {
@@ -16,7 +16,7 @@ func init() {
 
 var initCmd = &cobra.Command{
 	Use:   "init",
-	Short: "Initialize antidot for aliases and env vars to work",
+	Short: "Initialize antidot-home for aliases and env vars to work",
 	Run: func(cmd *cobra.Command, args []string) {
 		shell, err := sh.Get(shellOverride)
 		tui.FatalIfError("", err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/bad3r/antidot/internal/tui"
-	"github.com/bad3r/antidot/internal/utils"
+	"github.com/bad3r/antidot-home/internal/tui"
+	"github.com/bad3r/antidot-home/internal/utils"
 )
 
 var rulesFilePath string
@@ -16,7 +16,7 @@ var rulesFilePath string
 var shellOverride string
 
 var rootCmd = &cobra.Command{
-	Use:   "antidot",
+	Use:   "antidot-home",
 	Short: "Clean your $HOME from those pesky dotfiles",
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -1,8 +1,8 @@
 package cmd
 
 import (
-	"github.com/bad3r/antidot/internal/tui"
-	"github.com/bad3r/antidot/internal/utils"
+	"github.com/bad3r/antidot-home/internal/tui"
+	"github.com/bad3r/antidot-home/internal/utils"
 	"github.com/spf13/cobra"
 )
 
@@ -10,7 +10,7 @@ func init() {
 	rootCmd.AddCommand(updateCmd)
 }
 
-var rulesSource = "https://raw.githubusercontent.com/bad3r/antidot/main/rules.yaml"
+var rulesSource = "https://raw.githubusercontent.com/bad3r/antidot-home/main/rules.yaml"
 
 var updateCmd = &cobra.Command{
 	Use:   "update",

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/bad3r/antidot
+module github.com/bad3r/antidot-home
 
 go 1.21
 

--- a/internal/rules/action.go
+++ b/internal/rules/action.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/mitchellh/mapstructure"
 
-	"github.com/bad3r/antidot/internal/shell"
+	"github.com/bad3r/antidot-home/internal/shell"
 )
 
 type ActionContext struct {

--- a/internal/rules/alias.go
+++ b/internal/rules/alias.go
@@ -1,7 +1,7 @@
 package rules
 
 import (
-	"github.com/bad3r/antidot/internal/tui"
+	"github.com/bad3r/antidot-home/internal/tui"
 )
 
 type Alias struct {

--- a/internal/rules/alias_test.go
+++ b/internal/rules/alias_test.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/bad3r/antidot/internal/rules"
-	"github.com/bad3r/antidot/internal/shell"
-	"github.com/bad3r/antidot/internal/utils"
+	"github.com/bad3r/antidot-home/internal/rules"
+	"github.com/bad3r/antidot-home/internal/shell"
+	"github.com/bad3r/antidot-home/internal/utils"
 )
 
 func TestAliasNoEnv(t *testing.T) {

--- a/internal/rules/config.go
+++ b/internal/rules/config.go
@@ -4,7 +4,7 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/bad3r/antidot/internal/tui"
+	"github.com/bad3r/antidot-home/internal/tui"
 	"github.com/mitchellh/mapstructure"
 	"gopkg.in/yaml.v2"
 )

--- a/internal/rules/config_test.go
+++ b/internal/rules/config_test.go
@@ -7,9 +7,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/bad3r/antidot/internal/dotfile"
+	"github.com/bad3r/antidot-home/internal/dotfile"
 
-	"github.com/bad3r/antidot/internal/rules"
+	"github.com/bad3r/antidot-home/internal/rules"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/internal/rules/delete.go
+++ b/internal/rules/delete.go
@@ -3,8 +3,8 @@ package rules
 import (
 	"os"
 
-	"github.com/bad3r/antidot/internal/tui"
-	"github.com/bad3r/antidot/internal/utils"
+	"github.com/bad3r/antidot-home/internal/tui"
+	"github.com/bad3r/antidot-home/internal/utils"
 )
 
 type Delete struct {

--- a/internal/rules/delete_test.go
+++ b/internal/rules/delete_test.go
@@ -6,9 +6,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/bad3r/antidot/internal/rules"
-	"github.com/bad3r/antidot/internal/shell"
-	"github.com/bad3r/antidot/internal/utils"
+	"github.com/bad3r/antidot-home/internal/rules"
+	"github.com/bad3r/antidot-home/internal/shell"
+	"github.com/bad3r/antidot-home/internal/utils"
 )
 
 func TestDeleteApply(t *testing.T) {

--- a/internal/rules/export.go
+++ b/internal/rules/export.go
@@ -1,7 +1,7 @@
 package rules
 
 import (
-	"github.com/bad3r/antidot/internal/tui"
+	"github.com/bad3r/antidot-home/internal/tui"
 )
 
 type Export struct {

--- a/internal/rules/export_test.go
+++ b/internal/rules/export_test.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/bad3r/antidot/internal/rules"
-	"github.com/bad3r/antidot/internal/shell"
-	"github.com/bad3r/antidot/internal/utils"
+	"github.com/bad3r/antidot-home/internal/rules"
+	"github.com/bad3r/antidot-home/internal/shell"
+	"github.com/bad3r/antidot-home/internal/utils"
 )
 
 func TestExportNoEnv(t *testing.T) {

--- a/internal/rules/migrate.go
+++ b/internal/rules/migrate.go
@@ -4,8 +4,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/bad3r/antidot/internal/tui"
-	"github.com/bad3r/antidot/internal/utils"
+	"github.com/bad3r/antidot-home/internal/tui"
+	"github.com/bad3r/antidot-home/internal/utils"
 )
 
 type Migrate struct {

--- a/internal/rules/migrate_test.go
+++ b/internal/rules/migrate_test.go
@@ -6,9 +6,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/bad3r/antidot/internal/rules"
-	"github.com/bad3r/antidot/internal/shell"
-	"github.com/bad3r/antidot/internal/utils"
+	"github.com/bad3r/antidot-home/internal/rules"
+	"github.com/bad3r/antidot-home/internal/shell"
+	"github.com/bad3r/antidot-home/internal/utils"
 )
 
 func TestMigrateApply(t *testing.T) {

--- a/internal/rules/rule.go
+++ b/internal/rules/rule.go
@@ -1,8 +1,8 @@
 package rules
 
 import (
-	"github.com/bad3r/antidot/internal/dotfile"
-	"github.com/bad3r/antidot/internal/tui"
+	"github.com/bad3r/antidot-home/internal/dotfile"
+	"github.com/bad3r/antidot-home/internal/tui"
 )
 
 type Rule struct {

--- a/internal/shell/bash.go
+++ b/internal/shell/bash.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/bad3r/antidot/internal/utils"
+	"github.com/bad3r/antidot-home/internal/utils"
 )
 
 type Bash struct{}

--- a/internal/shell/bash_test.go
+++ b/internal/shell/bash_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/bad3r/antidot/internal/shell"
+	"github.com/bad3r/antidot-home/internal/shell"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/shell/fish.go
+++ b/internal/shell/fish.go
@@ -5,7 +5,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/bad3r/antidot/internal/utils"
+	"github.com/bad3r/antidot-home/internal/utils"
 )
 
 type Fish struct{}

--- a/internal/shell/fish_test.go
+++ b/internal/shell/fish_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/bad3r/antidot/internal/shell"
+	"github.com/bad3r/antidot-home/internal/shell"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/shell/keyvalue.go
+++ b/internal/shell/keyvalue.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"sync"
 
-	"github.com/bad3r/antidot/internal/tui"
-	"github.com/bad3r/antidot/internal/utils"
+	"github.com/bad3r/antidot-home/internal/tui"
+	"github.com/bad3r/antidot-home/internal/utils"
 )
 
 type KeyValueStore struct {

--- a/internal/shell/keyvalue_test.go
+++ b/internal/shell/keyvalue_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/bad3r/antidot/internal/shell"
+	"github.com/bad3r/antidot-home/internal/shell"
 	"github.com/google/go-cmp/cmp"
 )
 

--- a/internal/shell/shell_test.go
+++ b/internal/shell/shell_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/bad3r/antidot/internal/shell"
+	"github.com/bad3r/antidot-home/internal/shell"
 )
 
 type TestSh struct{}

--- a/internal/utils/appdirs.go
+++ b/internal/utils/appdirs.go
@@ -36,12 +36,12 @@ var AppDirs appDirs
 
 func init() {
 	// TODO: import this from somewhere
-	AppDirs = appDirs{AppName: "antidot"}
+	AppDirs = appDirs{AppName: "antidot-home"}
 }
 
 func GetKeyValueStorePath() (string, error) {
-	// Check if ANTIDOT_STATE_FILE environment variable is set
-	if stateFile := os.Getenv("ANTIDOT_STATE_FILE"); stateFile != "" {
+	// Check if ANTIDOT_HOME_STATE_FILE environment variable is set
+	if stateFile := os.Getenv("ANTIDOT_HOME_STATE_FILE"); stateFile != "" {
 		return stateFile, nil
 	}
 

--- a/internal/utils/env.go
+++ b/internal/utils/env.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/adrg/xdg"
 
-	"github.com/bad3r/antidot/internal/tui"
+	"github.com/bad3r/antidot-home/internal/tui"
 )
 
 func GetHomeDir() (string, error) {

--- a/internal/utils/fetch.go
+++ b/internal/utils/fetch.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"path"
 
-	"github.com/bad3r/antidot/internal/tui"
+	"github.com/bad3r/antidot-home/internal/tui"
 )
 
 func Download(src, dest string) error {

--- a/internal/utils/files.go
+++ b/internal/utils/files.go
@@ -6,7 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/bad3r/antidot/internal/tui"
+	"github.com/bad3r/antidot-home/internal/tui"
 	"github.com/otiai10/copy"
 )
 

--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/bad3r/antidot/cmd"
+	"github.com/bad3r/antidot-home/cmd"
 )
 
 /*

--- a/tests/integration/init_test.go
+++ b/tests/integration/init_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/bad3r/antidot/tests"
+	"github.com/bad3r/antidot-home/tests"
 	"github.com/stretchr/testify/require"
 )
 
@@ -75,14 +75,14 @@ func TestInitCommand(t *testing.T) {
 	defer env.Cleanup()
 
 	t.Run("init without shell override", func(t *testing.T) {
-		antidotPath := tests.GetAntidotPath(t)
-		initCmd := exec.Command(antidotPath, "init")
+		antidotHomePath := tests.GetAntidotHomePath(t)
+		initCmd := exec.Command(antidotHomePath, "init")
 
 		// Pass the current environment to ensure XDG variables are available
 		initCmd.Env = os.Environ()
 
 		output, err := initCmd.Output()
-		require.NoError(t, err, "antidot init failed")
+		require.NoError(t, err, "antidot-home init failed")
 
 		outputStr := string(output)
 		normalizedOutput := normalizeOutput(outputStr)
@@ -96,14 +96,14 @@ func TestInitCommand(t *testing.T) {
 	})
 
 	t.Run("init with bash shell", func(t *testing.T) {
-		antidotPath := tests.GetAntidotPath(t)
-		initCmd := exec.Command(antidotPath, "init", "--shell", "bash")
+		antidotHomePath := tests.GetAntidotHomePath(t)
+		initCmd := exec.Command(antidotHomePath, "init", "--shell", "bash")
 
 		// Pass the current environment to ensure XDG variables are available
 		initCmd.Env = os.Environ()
 
 		output, err := initCmd.Output()
-		require.NoError(t, err, "antidot init --shell bash failed")
+		require.NoError(t, err, "antidot-home init --shell bash failed")
 
 		outputStr := string(output)
 		normalizedOutput := normalizeOutput(outputStr)
@@ -117,14 +117,14 @@ func TestInitCommand(t *testing.T) {
 	})
 
 	t.Run("init with fish shell", func(t *testing.T) {
-		antidotPath := tests.GetAntidotPath(t)
-		initCmd := exec.Command(antidotPath, "init", "--shell", "fish")
+		antidotHomePath := tests.GetAntidotHomePath(t)
+		initCmd := exec.Command(antidotHomePath, "init", "--shell", "fish")
 
 		// Pass the current environment to ensure XDG variables are available
 		initCmd.Env = os.Environ()
 
 		output, err := initCmd.Output()
-		require.NoError(t, err, "antidot init --shell fish failed")
+		require.NoError(t, err, "antidot-home init --shell fish failed")
 
 		outputStr := string(output)
 		normalizedOutput := normalizeOutput(outputStr)
@@ -138,14 +138,14 @@ func TestInitCommand(t *testing.T) {
 	})
 
 	t.Run("init with zsh shell", func(t *testing.T) {
-		antidotPath := tests.GetAntidotPath(t)
-		initCmd := exec.Command(antidotPath, "init", "--shell", "zsh")
+		antidotHomePath := tests.GetAntidotHomePath(t)
+		initCmd := exec.Command(antidotHomePath, "init", "--shell", "zsh")
 
 		// Pass the current environment to ensure XDG variables are available
 		initCmd.Env = os.Environ()
 
 		output, err := initCmd.Output()
-		require.NoError(t, err, "antidot init --shell zsh failed")
+		require.NoError(t, err, "antidot-home init --shell zsh failed")
 
 		outputStr := string(output)
 		normalizedOutput := normalizeOutput(outputStr)
@@ -159,10 +159,10 @@ func TestInitCommand(t *testing.T) {
 	})
 
 	t.Run("init with invalid shell", func(t *testing.T) {
-		antidotPath := tests.GetAntidotPath(t)
-		initCmd := exec.Command(antidotPath, "init", "--shell", "invalid_shell")
+		antidotHomePath := tests.GetAntidotHomePath(t)
+		initCmd := exec.Command(antidotHomePath, "init", "--shell", "invalid_shell")
 		_, err := initCmd.Output()
-		require.Error(t, err, "antidot init with invalid shell should fail")
+		require.Error(t, err, "antidot-home init with invalid shell should fail")
 
 		// Check that the error message mentions supported shells
 		if exitErr, ok := err.(*exec.ExitError); ok {
@@ -187,15 +187,15 @@ func TestInitWithKeyValueStore(t *testing.T) {
 		require.NoError(t, err, "Failed to write test key-value store")
 		tmpFile.Close()
 
-		// Run antidot init with the custom key-value store
-		antidotPath := tests.GetAntidotPath(t)
-		initCmd := exec.Command(antidotPath, "init", "--shell", "bash")
+		// Run antidot-home init with the custom key-value store
+		antidotHomePath := tests.GetAntidotHomePath(t)
+		initCmd := exec.Command(antidotHomePath, "init", "--shell", "bash")
 
-		// Set the ANTIDOT_STATE_FILE environment variable
-		initCmd.Env = append(os.Environ(), "ANTIDOT_STATE_FILE="+tmpFile.Name())
+		// Set the ANTIDOT_HOME_STATE_FILE environment variable
+		initCmd.Env = append(os.Environ(), "ANTIDOT_HOME_STATE_FILE="+tmpFile.Name())
 
 		output, err := initCmd.Output()
-		require.NoError(t, err, "antidot init failed")
+		require.NoError(t, err, "antidot-home init failed")
 
 		outputStr := string(output)
 		normalizedOutput := normalizeOutput(outputStr)
@@ -219,15 +219,15 @@ func TestInitWithKeyValueStore(t *testing.T) {
 		require.NoError(t, err, "Failed to write test key-value store")
 		tmpFile.Close()
 
-		// Run antidot init with fish shell
-		antidotPath := tests.GetAntidotPath(t)
-		initCmd := exec.Command(antidotPath, "init", "--shell", "fish")
+		// Run antidot-home init with fish shell
+		antidotHomePath := tests.GetAntidotHomePath(t)
+		initCmd := exec.Command(antidotHomePath, "init", "--shell", "fish")
 
-		// Set the ANTIDOT_STATE_FILE environment variable
-		initCmd.Env = append(os.Environ(), "ANTIDOT_STATE_FILE="+tmpFile.Name())
+		// Set the ANTIDOT_HOME_STATE_FILE environment variable
+		initCmd.Env = append(os.Environ(), "ANTIDOT_HOME_STATE_FILE="+tmpFile.Name())
 
 		output, err := initCmd.Output()
-		require.NoError(t, err, "antidot init failed")
+		require.NoError(t, err, "antidot-home init failed")
 
 		outputStr := string(output)
 		normalizedOutput := normalizeOutput(outputStr)
@@ -246,18 +246,18 @@ func TestInitCommandOutputConsistency(t *testing.T) {
 	defer env.Cleanup()
 
 	t.Run("init output is consistent across runs", func(t *testing.T) {
-		antidotPath := tests.GetAntidotPath(t)
+		antidotHomePath := tests.GetAntidotHomePath(t)
 
-		// Run antidot init multiple times
-		initCmd1 := exec.Command(antidotPath, "init", "--shell", "bash")
+		// Run antidot-home init multiple times
+		initCmd1 := exec.Command(antidotHomePath, "init", "--shell", "bash")
 		initCmd1.Env = os.Environ()
 		output1, err := initCmd1.Output()
-		require.NoError(t, err, "First antidot init failed")
+		require.NoError(t, err, "First antidot-home init failed")
 
-		initCmd2 := exec.Command(antidotPath, "init", "--shell", "bash")
+		initCmd2 := exec.Command(antidotHomePath, "init", "--shell", "bash")
 		initCmd2.Env = os.Environ()
 		output2, err := initCmd2.Output()
-		require.NoError(t, err, "Second antidot init failed")
+		require.NoError(t, err, "Second antidot-home init failed")
 
 		// The output should contain the same content, but order may vary due to map iteration
 		output1Str := string(output1)
@@ -297,15 +297,15 @@ func TestInitCommandFormatting(t *testing.T) {
 		require.NoError(t, err, "Failed to write test key-value store")
 		tmpFile.Close()
 
-		// Run antidot init
-		antidotPath := tests.GetAntidotPath(t)
-		initCmd := exec.Command(antidotPath, "init", "--shell", "bash")
+		// Run antidot-home init
+		antidotHomePath := tests.GetAntidotHomePath(t)
+		initCmd := exec.Command(antidotHomePath, "init", "--shell", "bash")
 
-		// Set the ANTIDOT_STATE_FILE environment variable
-		initCmd.Env = append(os.Environ(), "ANTIDOT_STATE_FILE="+tmpFile.Name())
+		// Set the ANTIDOT_HOME_STATE_FILE environment variable
+		initCmd.Env = append(os.Environ(), "ANTIDOT_HOME_STATE_FILE="+tmpFile.Name())
 
 		output, err := initCmd.Output()
-		require.NoError(t, err, "antidot init failed")
+		require.NoError(t, err, "antidot-home init failed")
 
 		outputStr := string(output)
 		normalizedOutput := normalizeOutput(outputStr)
@@ -329,15 +329,15 @@ func TestInitCommandFormatting(t *testing.T) {
 		require.NoError(t, err, "Failed to write test key-value store")
 		tmpFile.Close()
 
-		// Run antidot init
-		antidotPath := tests.GetAntidotPath(t)
-		initCmd := exec.Command(antidotPath, "init", "--shell", "fish")
+		// Run antidot-home init
+		antidotHomePath := tests.GetAntidotHomePath(t)
+		initCmd := exec.Command(antidotHomePath, "init", "--shell", "fish")
 
-		// Set the ANTIDOT_STATE_FILE environment variable
-		initCmd.Env = append(os.Environ(), "ANTIDOT_STATE_FILE="+tmpFile.Name())
+		// Set the ANTIDOT_HOME_STATE_FILE environment variable
+		initCmd.Env = append(os.Environ(), "ANTIDOT_HOME_STATE_FILE="+tmpFile.Name())
 
 		output, err := initCmd.Output()
-		require.NoError(t, err, "antidot init failed")
+		require.NoError(t, err, "antidot-home init failed")
 
 		outputStr := string(output)
 		normalizedOutput := normalizeOutput(outputStr)
@@ -361,15 +361,15 @@ func TestInitCommandFormatting(t *testing.T) {
 		require.NoError(t, err, "Failed to write test key-value store")
 		tmpFile.Close()
 
-		// Run antidot init
-		antidotPath := tests.GetAntidotPath(t)
-		initCmd := exec.Command(antidotPath, "init", "--shell", "bash")
+		// Run antidot-home init
+		antidotHomePath := tests.GetAntidotHomePath(t)
+		initCmd := exec.Command(antidotHomePath, "init", "--shell", "bash")
 
-		// Set the ANTIDOT_STATE_FILE environment variable
-		initCmd.Env = append(os.Environ(), "ANTIDOT_STATE_FILE="+tmpFile.Name())
+		// Set the ANTIDOT_HOME_STATE_FILE environment variable
+		initCmd.Env = append(os.Environ(), "ANTIDOT_HOME_STATE_FILE="+tmpFile.Name())
 
 		output, err := initCmd.Output()
-		require.NoError(t, err, "antidot init failed")
+		require.NoError(t, err, "antidot-home init failed")
 
 		outputStr := string(output)
 		normalizedOutput := normalizeOutput(outputStr)
@@ -393,15 +393,15 @@ func TestInitCommandFormatting(t *testing.T) {
 		require.NoError(t, err, "Failed to write test key-value store")
 		tmpFile.Close()
 
-		// Run antidot init
-		antidotPath := tests.GetAntidotPath(t)
-		initCmd := exec.Command(antidotPath, "init", "--shell", "fish")
+		// Run antidot-home init
+		antidotHomePath := tests.GetAntidotHomePath(t)
+		initCmd := exec.Command(antidotHomePath, "init", "--shell", "fish")
 
-		// Set the ANTIDOT_STATE_FILE environment variable
-		initCmd.Env = append(os.Environ(), "ANTIDOT_STATE_FILE="+tmpFile.Name())
+		// Set the ANTIDOT_HOME_STATE_FILE environment variable
+		initCmd.Env = append(os.Environ(), "ANTIDOT_HOME_STATE_FILE="+tmpFile.Name())
 
 		output, err := initCmd.Output()
-		require.NoError(t, err, "antidot init failed")
+		require.NoError(t, err, "antidot-home init failed")
 
 		outputStr := string(output)
 		normalizedOutput := normalizeOutput(outputStr)

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/bad3r/antidot/internal/utils"
+	"github.com/bad3r/antidot-home/internal/utils"
 	"github.com/stretchr/testify/require"
 )
 
@@ -26,7 +26,7 @@ func SetupTestEnv(t *testing.T) *TestEnv {
 
 	// Override the app directories to use our temp directory
 	originalAppName := utils.AppDirs.AppName
-	utils.AppDirs.AppName = "antidot_test"
+	utils.AppDirs.AppName = "antidot_home_test"
 
 	// Set all XDG variables to our temp directory to ensure complete isolation
 	originalXdgDataHome := os.Getenv("XDG_DATA_HOME")
@@ -61,9 +61,9 @@ func (te *TestEnv) Cleanup() {
 	os.Setenv("XDG_RUNTIME_DIR", te.OriginalXdgRuntimeDir)
 }
 
-// GetAntidotPath returns the absolute path to the antidot binary
-func GetAntidotPath(t *testing.T) string {
-	antidotPath, err := filepath.Abs("../../antidot")
-	require.NoError(t, err, "Failed to get absolute path to antidot")
-	return antidotPath
+// GetAntidotHomePath returns the absolute path to the antidot-home binary
+func GetAntidotHomePath(t *testing.T) string {
+	antidotHomePath, err := filepath.Abs("../../antidot-home")
+	require.NoError(t, err, "Failed to get absolute path to antidot-home")
+	return antidotHomePath
 }


### PR DESCRIPTION
## Summary
This PR renames the repository from `antidot` to `antidot-home` to differentiate this fork from the original project.

## Changes

### Code and Configuration
- Updated Go module name to `github.com/bad3r/antidot-home`
- Updated all Go import paths throughout the codebase
- Updated binary names to `antidot-home` in:
  - `.goreleaser.yml`
  - `.gitignore`
  - GitHub workflows

### Application Identity
- Changed application name to `antidot-home` in `utils/appdirs.go`
  - This changes data directory from `$XDG_DATA_HOME/antidot/` to `$XDG_DATA_HOME/antidot-home/`
- Updated environment variable from `ANTIDOT_STATE_FILE` to `ANTIDOT_HOME_STATE_FILE`

### Documentation
- Updated README title to "AntiDot Home"
- Updated all command examples to use `antidot-home`
- Updated installation instructions for AUR package

### Repository References
- Updated all GitHub URLs to point to `antidot-home`
- Updated AUR package names to `antidot-home-bin`
- Kept Homebrew configuration as is (no tap for this fork)

### Tests
- Updated test binary paths and function names
- Updated test environment variables

## Test Plan
- [x] Ran `go mod tidy` to update dependencies
- [x] Tested workflows with `act`
- [x] All import paths resolve correctly
- [ ] CI/CD pipeline will validate changes

## Migration Notes
Users migrating from `antidot` to `antidot-home` should note:
- Data directory changes from `~/.local/share/antidot/` to `~/.local/share/antidot-home/`
- Command changes from `antidot` to `antidot-home`
- Environment variable changes from `ANTIDOT_STATE_FILE` to `ANTIDOT_HOME_STATE_FILE`

## Post-Merge Actions
After this PR is merged:
1. The GitHub repository should be renamed from `antidot` to `antidot-home`
2. Update any external services or integrations
3. Update AUR package repository